### PR TITLE
Use multiple 3.x python versions during CI

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -16,9 +16,9 @@ jobs:
 
     - name: install specklesnake
       run: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      pip install -e .
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -e .
 
     - name: run tests
       run: python -m unittest discover -v .

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -3,14 +3,22 @@ on: [pull_request]
 jobs:
   test-linux:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
     steps:
     - name: checkout
       uses: actions/checkout@v2
+    
+    - name: setup python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
 
     - name: install specklesnake
-      run: pip install -r requirements.txt && pip install -e .
-      shell: bash
+      run: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -e .
 
     - name: run tests
       run: python -m unittest discover -v .
-      shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 **Added:**
 
+- Add python version matrix to CI runs [\#8](https://github.com/stpotter16/specklesnake/pull/8)
 - Add Github Action for unittests on Linux [\#6](https://github.com/stpotter16/specklesnake/pull/6)
 - Add setup.py and setup.cfg [\#5](https://github.com/stpotter16/specklesnake/pull/5)
 - Add Bspline basis function tests [\#4](https://github.com/stpotter16/specklesnake/pull/4)


### PR DESCRIPTION
Fix recent CI failures in #7 that stem from using the default python 2.7 version on the runner machine.